### PR TITLE
log total gas spent by all parties

### DIFF
--- a/common/two-chain-setup.ts
+++ b/common/two-chain-setup.ts
@@ -123,3 +123,11 @@ export async function logBalances(...actors: Actor[]) {
     await actor.logBalances();
   }
 }
+
+export async function logTotalGasSpentByAll(...actors: Actor[]) {
+  let total = 0;
+  for (const actor of actors) {
+    total += actor.gasSpent;
+  }
+  console.log("Total gas spent by all parties: " + total);
+}

--- a/nitro-atomic-swap/happy-case.ts
+++ b/nitro-atomic-swap/happy-case.ts
@@ -4,6 +4,7 @@ import { LEFT_CHAIN_ID, RIGHT_CHAIN_ID } from "../constants";
 import {
   Executor,
   logBalances,
+  logTotalGasSpentByAll,
   Responder,
   spinUpChains,
 } from "../common/two-chain-setup";
@@ -138,6 +139,7 @@ const { leftChain, rightChain, tearDownChains } = spinUpChains();
   ]);
 
   await logBalances(executor, responder);
+  logTotalGasSpentByAll(executor, responder);
 
   // teardown blockchains
   await tearDownChains();

--- a/vector-atomic-swap/happy-case.ts
+++ b/vector-atomic-swap/happy-case.ts
@@ -7,6 +7,7 @@ import {
   Responder,
   spinUpChains,
   logBalances,
+  logTotalGasSpentByAll,
 } from "../common/two-chain-setup";
 import {
   deployContractsToChain,
@@ -114,6 +115,7 @@ const { leftChain, rightChain, tearDownChains } = spinUpChains();
   );
 
   await logBalances(executor, responder);
+  logTotalGasSpentByAll(executor, responder);
 
   // teardown blockchains
   await tearDownChains();


### PR DESCRIPTION
Fixes The total cost across all participants could be clearer #2

```terminal
➜  cross-chain git:(total-cost) yarn go-vector
yarn run v1.22.1
$ ts-node ./vector-atomic-swap/happy-case.ts
ganache listening on port 9002...
ganache listening on port 9001...
> I have 10000000000 tokens on the left chain
> I have 0 tokens on the right chain
...
> I have 2 tokens on the right chain
< I have 2 tokens on the left chain
< I have 9999999998 tokens on the right chain
Total gas spent by all parties: 645915
✨  Done in 10.14s.
➜  cross-chain git:(total-cost) ✗ yarn go-nitro 
yarn run v1.22.1
$ ts-node ./nitro-atomic-swap/happy-case.ts
ganache listening on port 9001...
ganache listening on port 9002...
> I have 10000000000 tokens on the left chain
> I have 0 tokens on the right chain
< I have 0 tokens on the left chain
< I have 10000000000 tokens on the right chain
> I propose a hashlocked payment, sending PreFund0 for chain 0x42
< Sure thing. Your channel looks good. Sending PreFund1 for chain 0x42
...
< I have 9999999998 tokens on the right chain
Total gas spent by all parties: 423574
✨  Done in 16.79s.
➜  cross-chain git:(total-cost) ✗ 
```