### PR TITLE
preload nitro AssetHolder with a token

### DIFF
--- a/nitro-atomic-swap/helpers.ts
+++ b/nitro-atomic-swap/helpers.ts
@@ -47,6 +47,12 @@ export async function deployContractsToChain(
     deployer
   ).deploy();
 
+  await (
+    await token
+      .connect(chain.getSigner(0))
+      .transfer(erc20AssetHolder.address, 1)
+  ).wait(); // preload assetholder to represent real-world usage
+
   return [nitroAdjudicator, erc20AssetHolder, hashLock, token].map((contract) =>
     contract.connect(chain.getSigner(0))
   );


### PR DESCRIPTION
means that deposits are cheaper (the storage slot for the AssetHolder is already warm)

means that payouts are more expensive (the same slot for the AssetHolder is not zero-ed out, so no refund)